### PR TITLE
Add check for category on `new` command

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -53,7 +53,7 @@ class App():
         return False
     
     def create_project(self, project_name:str, category:str="backlogged", description:str="") -> bool:
-        if project_name not in self.__projects:
+        if project_name not in self.__projects and category in self.__CATEGORIES:
             self.__projects[project_name] = {
                 "category": category,
                 "description": description

--- a/src/cli.py
+++ b/src/cli.py
@@ -52,7 +52,7 @@ def __new(args:list):
         case True:
             print(f"Created new project '{args[0]}'")
         case False:
-            print(f"Failed to create new project '{args[0]}' (maybe it already exists?)")
+            print(f"Failed to create new project '{args[0]}' (maybe it already exists, or the category is invalid?)")
         case _:
             print(f"WARNING: Received unexpected return value {output} from App.create_project()")
 


### PR DESCRIPTION
Add a check to the category passed in when calling `App.create_project()`, failing if the category is invalid.
Update the CLI failure message for the `new` command to reflect the update to `App.create_project()`.

Fixes #1.